### PR TITLE
fix: use Origins-Pattern format for Ubuntu unattended-upgrade origins

### DIFF
--- a/molecule/default/test.convergence
+++ b/molecule/default/test.convergence
@@ -1,1 +1,2 @@
 debian12
+ubuntu2404

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,7 @@
 - name: 'Verify'
   hosts: 'all'
   check_mode: true
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: 'Ensure test package installed'
       ansible.builtin.apt:
@@ -10,3 +10,29 @@
         state: 'present'
       register: result
       failed_when: result.changed
+
+    - name: 'Verify Ubuntu unattended-upgrades Origins-Pattern uses archive= key'
+      when: ansible_facts['distribution'] == 'Ubuntu'
+      block:
+        - name: 'Read 51unattended-upgrades'
+          ansible.builtin.slurp:
+            src: '/etc/apt/apt.conf.d/51unattended-upgrades'
+          register: unattended_cfg
+
+        - name: 'Assert archive= key present for security suite'
+          ansible.builtin.assert:
+            that:
+              - >-
+                unattended_cfg['content'] | b64decode
+                | regex_findall('codename=[^;)]+')
+                | select('match', '.*-security.*')
+                | list | length == 0
+              - >-
+                unattended_cfg['content'] | b64decode
+                | regex_findall('codename=[^;)]+')
+                | select('match', '.*-updates.*')
+                | list | length == 0
+              - "'archive=' in (unattended_cfg['content'] | b64decode)"
+            fail_msg: >-
+              Origins-Pattern for Ubuntu must use 'archive=' not 'codename=' for
+              suite names ending in '-security'/'-updates'.

--- a/templates/apt-unattended.j2
+++ b/templates/apt-unattended.j2
@@ -7,8 +7,8 @@ Unattended-Upgrade::Origins-Pattern {
   "origin=Debian,codename=${distro_codename}-security,label=Debian-Security;"
   {% endif %}
   {%- elif ansible_facts['distribution'] == 'Ubuntu' -%}
-  "${distro_id}:${distro_codename}-security";
-  "${distro_id}:${distro_codename}-updates";
+  "origin=${distro_id},codename=${distro_codename}-security,label=${distro_id}-Security";
+  "origin=${distro_id},codename=${distro_codename}-updates,label=${distro_id}-Updates";
   {% endif %}
   {%- for origin in apt_unattended_origins -%}
   "{{ origin }}";

--- a/templates/apt-unattended.j2
+++ b/templates/apt-unattended.j2
@@ -7,8 +7,8 @@ Unattended-Upgrade::Origins-Pattern {
   "origin=Debian,codename=${distro_codename}-security,label=Debian-Security;"
   {% endif %}
   {%- elif ansible_facts['distribution'] == 'Ubuntu' -%}
-  "origin=${distro_id},codename=${distro_codename}-security,label=${distro_id}-Security";
-  "origin=${distro_id},codename=${distro_codename}-updates,label=${distro_id}-Updates";
+  "origin=${distro_id},archive=${distro_codename}-security,label=${distro_id}-Security";
+  "origin=${distro_id},archive=${distro_codename}-updates,label=${distro_id}-Updates";
   {% endif %}
   {%- for origin in apt_unattended_origins -%}
   "{{ origin }}";


### PR DESCRIPTION
The Ubuntu entries were using Allowed-Origins colon syntax (${distro_id}:${distro_codename}-security) inside the Origins-Pattern block. The Origins-Pattern parser splits on '=' and expects key=value pairs, causing a ValueError when only one value is unpacked.

Fixes: ValueError: not enough values to unpack (expected 2, got 1)